### PR TITLE
fix css bug for title on mobile

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -788,6 +788,10 @@ mimicks leaflet's zoom ui */
     position: static;
   }
 
+  #intro_and_slides #intro {
+    height: 140px;
+  }
+
   /*hide map and UI on mobile*/
   .ui, #map, #slides_container, #slides * {
     display: none;


### PR DESCRIPTION
Fixes title on landing page when viewed on mobile.

### Now
![screen shot 2015-02-16 at 10 29 14 am](https://cloud.githubusercontent.com/assets/161748/6214450/a6ea46f2-b5c6-11e4-996d-f4fe8be6eeb6.png)

### Was:
![screen shot 2015-02-16 at 10 27 52 am](https://cloud.githubusercontent.com/assets/161748/6214429/797cbcb8-b5c6-11e4-8dba-9c94b6757f1f.png)
